### PR TITLE
chore: bump google-services version

### DIFF
--- a/packages/flutterfire_cli/lib/src/firebase/firebase_android_writes.dart
+++ b/packages/flutterfire_cli/lib/src/firebase/firebase_android_writes.dart
@@ -32,7 +32,7 @@ final _androidAppBuildGradleGoogleServicesRegex = RegExp(
 const _googleServicesPluginClass = 'com.google.gms:google-services';
 const _googleServicesPluginName = 'com.google.gms.google-services';
 // TODO read from firebase_core pubspec.yaml firebase.google_services_gradle_plugin_version
-const _googleServicesPluginVersion = '4.3.10';
+const _googleServicesPluginVersion = '4.3.15';
 const _googleServicesPlugin =
     "classpath '$_googleServicesPluginClass:$_googleServicesPluginVersion'";
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

The current version of google-services (4.3.10) results in failing android build from a new Flutter project. This change bumps to version 4.3.15 which works with latest Flutter setup.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [x] 🗑️ `chore` -- Chore
